### PR TITLE
CentOS 7, Ansible and the end of Python 2

### DIFF
--- a/_posts/2020-02-21-centos7-python2-end-of-life.md
+++ b/_posts/2020-02-21-centos7-python2-end-of-life.md
@@ -10,12 +10,16 @@ tags:
   - continuous-integration
 ---
 
-The [sunsetting of Python 2](https://www.python.org/doc/sunset-python-2/) on 1 January 2020 has been causing problems our CentOS 7 server administration.
+Python 2 vs 3 mismatches have been causing problems in our
+CentOS 7 server adminstration.
 We use [Ansible](https://www.ansible.com/) for automatic configuration and
-a few of our long-used jobs recently began to fail as a result Python 2 / Python 3 mismatches.
-Officially, CentOS 7 is [supported until
-June 2024](https://wiki.centos.org/About/Product), but I think the end of
-Python 2 will hasten its demise.
+continuous integration deployments.
+A few of our long-used jobs recently broke because Python 2 dependencies were out-of-date.
+CentOS 7 itself depends on Python 2.
+It is officially [supported until
+June 2024](https://wiki.centos.org/About/Product), but I think that the [sunsetting
+of Python 2](https://www.python.org/doc/sunset-python-2/) will hasten its
+demise.
 
 The notes below explain how we solved our issues with CentOS 7 and Ansible.
 Hopefully they will be helpful to others.
@@ -102,7 +106,7 @@ hierarchy](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variable
 In the example above, the variable only applies for a single
 task and Python 2 is used elsewhere.  We find this preferable to setting for
 an entire host or play as the intention is most
-explicit and some other modules, notably `yum`, will only work with Python
+explicit and some modules, notably `yum`, will only work with Python
 2.
 
 Trivia: `yum` ("Yellowdog updater, modified") is the package manager in CentOS 7.  It requires Python 2.  CentOS 8 uses `dnf` package manager ("Dandified Yum"), which can use Python 3.

--- a/_posts/2020-02-21-centos7-python2-end-of-life.md
+++ b/_posts/2020-02-21-centos7-python2-end-of-life.md
@@ -110,8 +110,7 @@ Ansible reads variable definitions according to a [defined
 hierarchy](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable).
 In the example above, the variable only applies for a single
 task and Python 2 is used elsewhere.  We find this preferable to setting for
-an entire host or play as the intention is most
-explicit and some modules, notably `yum`, will only work with Python
-2.
+an entire host or playbook because it makes the intention more explicit.
+Also, some modules (notably `yum`) will only work with Python 2, so using Python 3 for the whole playbook will break those steps.
 
 Trivia: `yum` ("Yellowdog updater, modified") is the package manager in CentOS 7.  It requires Python 2.  CentOS 8 uses `dnf` package manager ("Dandified Yum"), which can use Python 3.

--- a/_posts/2020-02-21-centos7-python2-end-of-life.md
+++ b/_posts/2020-02-21-centos7-python2-end-of-life.md
@@ -1,0 +1,106 @@
+---
+title:  "CentOS 7, Ansible and the end of Python 2"
+author: Dr John A Stevenson
+categories:
+  - devops
+tags:
+  - Python
+  - CentOS
+  - Ansible
+  - continuous-integration
+---
+
+The [sunsetting of Python 2](https://www.python.org/doc/sunset-python-2/) on 1 January 2020 has started to cause problems with administering our CentOS 7 servers.
+We use [Ansible](https://www.ansible.com/) for automatic configuration and
+a few of our long-running jobs recently began to fail as a result Python 2 / Python 3 mistmatches.
+Officially, CentOS 7 is [supported until
+2024-06-30](https://wiki.centos.org/About/Product), but I think the end of
+Python 2 will hasten its demise.
+
+The notes below explain how we solved our issues with CentOS 7 and Ansible.
+Hopefully they will be helpful to others.
+
+
+## Background
+
+When you configure a machine with Ansible, it connects to it via SSH and runs
+shell scripts and/or Python scripts to apply the settings that you requested.
+In CentOS 7, these scripts are run by Python 2.7.
+This causes the following problems with Python tools installed using the `pip`
+package manager.  
+
+
+  - An increasing number of packages are Python 3 only, and others e.g. `docker-compose`, are not being updated for Python 2.  As Ansible's `pip` module uses the system Python 2 interpreter by default, it may fail or get an out-of-date version.
+  - Other Ansible modules (e.g. `docker-compose, `nsupdate`), rely on Python
+    libraries installed on the system.  By default, Ansible will try to use
+the Python 2 version.  Again, these may be old or may not even exist.
+
+
+## Making Ansible work with Python 3
+
+The solution to this is to make Ansible use Python 3 on the target system.  The
+following steps allow this:
+
+### Ensure Python 3 and pip are present
+
+The following tasks ensure the server is able to use Python 3.
+
+```yaml
+---
+- name: Install latest python 3 and pip3
+  yum:
+    name:
+      - python36
+      - libselinux-python
+    state: present
+
+- name: Install SELinux for Python 3
+  pip:
+    name:
+      - selinux
+    state: present
+    executable: pip3
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+```
+
+Note that `pip3` is automatically installed with Python 3.6, and that the
+SELinux dependencies are required by some Ansible modules.
+
+### Use pip3 to install packages
+
+The Ansible `pip` module has a flag to specify `pip3`.  Use this to install
+packages to the system's Python 3.
+
+```yaml
+- name: Install ETLHelper
+  pip:
+    name:
+      - etlhelper
+    state: present
+    executable: pip3
+```
+
+### Tell Ansible to use Python 3 interpreter where required
+
+Ansible uses the `ansible_python_interpreter` variable to define with Python to
+use.  This must be specified wherever a module uses a Python 3 dependency e.g.
+
+```yaml
+- name: Use dnsupdate to update ip host
+  nsupdate:
+    server: "{{ dns_server }}"
+    zone: "{{ dns_path }}"
+    record: "{{ ansible_hostname }}"
+    value: "{{ ansible_default_ipv4.address }}"
+    ttl: 600
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+```
+
+Ansible reads variable definitions according to a [defined
+hierarchy](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable).
+In the example above, the variable sets Python 3 as interpreter for a single
+task and Python 2 is used elsewhere.  We find this preferable as it is most
+explicit and some other modules, most notably `yum`, will only work with Python
+2.

--- a/_posts/2020-02-21-centos7-python2-end-of-life.md
+++ b/_posts/2020-02-21-centos7-python2-end-of-life.md
@@ -67,7 +67,8 @@ SELinux dependencies are required by some Ansible modules.
 
 ### Use pip3 to install packages
 
-The Ansible `pip` module has a flag to specify `pip3`.  Use this to install
+The Ansible `pip` module has a `executable` option to specify which `pip` to
+use.  Use this to install
 packages to the system's Python 3.
 
 ```yaml

--- a/_posts/2020-02-21-centos7-python2-end-of-life.md
+++ b/_posts/2020-02-21-centos7-python2-end-of-life.md
@@ -103,3 +103,6 @@ task and Python 2 is used elsewhere.  We find this preferable to setting for
 an entire host or play as the intention is most
 explicit and some other modules, notably `yum`, will only work with Python
 2.
+
+Trivia: `yum` ("Yellowdog updater, modified") is the package manager in CentOS
+7.  It requires Python 2.  CentOS 8 uses `dnf` package manager ("Dandified Yum"), which can use Python 3.

--- a/_posts/2020-02-21-centos7-python2-end-of-life.md
+++ b/_posts/2020-02-21-centos7-python2-end-of-life.md
@@ -49,7 +49,7 @@ The following tasks ensure the server is able to use Python 3.
 
 ```yaml
 ---
-- name: Install latest python 3 and pip3
+- name: Install python 3.6 and pip3
   yum:
     name:
       - python36
@@ -66,7 +66,9 @@ The following tasks ensure the server is able to use Python 3.
     ansible_python_interpreter: /usr/bin/python3
 ```
 
-Note that `pip3` is automatically installed with Python 3.6 and that the
+Note that Python 3 is not available in the default repositories, so it is
+necessary to [enable the EPEL repo](https://fedoraproject.org/wiki/EPEL) or
+similar.  EPEL has Python 3.6, which automatically includes `pip3`.  The
 SELinux dependencies are required by some Ansible modules.
 
 ### Use pip3 to install packages

--- a/_posts/2020-02-21-centos7-python2-end-of-life.md
+++ b/_posts/2020-02-21-centos7-python2-end-of-life.md
@@ -10,11 +10,11 @@ tags:
   - continuous-integration
 ---
 
-The [sunsetting of Python 2](https://www.python.org/doc/sunset-python-2/) on 1 January 2020 has started to cause problems with administering our CentOS 7 servers.
+The [sunsetting of Python 2](https://www.python.org/doc/sunset-python-2/) on 1 January 2020 has started to cause problems our CentOS 7 server administration.
 We use [Ansible](https://www.ansible.com/) for automatic configuration and
-a few of our long-running jobs recently began to fail as a result Python 2 / Python 3 mistmatches.
+a few of our long-used jobs recently began to fail as a result Python 2 / Python 3 mismatches.
 Officially, CentOS 7 is [supported until
-2024-06-30](https://wiki.centos.org/About/Product), but I think the end of
+June 2024](https://wiki.centos.org/About/Product), but I think the end of
 Python 2 will hasten its demise.
 
 The notes below explain how we solved our issues with CentOS 7 and Ansible.
@@ -23,23 +23,21 @@ Hopefully they will be helpful to others.
 
 ## Background
 
-When you configure a machine with Ansible, it connects to it via SSH and runs
+Ansible configures servers by connecting via SSH and running
 shell scripts and/or Python scripts to apply the settings that you requested.
 In CentOS 7, these scripts are run by Python 2.7.
-This causes the following problems with Python tools installed using the `pip`
-package manager.  
+This causes two main problems with Python tools installed using the `pip`
+package manager:
 
-
-  - An increasing number of packages are Python 3 only, and others e.g. `docker-compose`, are not being updated for Python 2.  As Ansible's `pip` module uses the system Python 2 interpreter by default, it may fail or get an out-of-date version.
-  - Other Ansible modules (e.g. `docker-compose, `nsupdate`), rely on Python
-    libraries installed on the system.  By default, Ansible will try to use
-the Python 2 version.  Again, these may be old or may not even exist.
+  - An increasing number of packages are Python 3 only, and others are not receiving updates for Python 2.  Ansible's `pip` module uses the system Python 2 interpreter by default, so it may fail or get an out-of-date version.
+  - Other Ansible modules rely on Python libraries installed on the system.  By default, Ansible will try to use
+the Python 2 version.  Again, these may be missing or old.
 
 
 ## Making Ansible work with Python 3
 
 The solution to this is to make Ansible use Python 3 on the target system.  The
-following steps allow this:
+following steps are required:
 
 ### Ensure Python 3 and pip are present
 
@@ -64,7 +62,7 @@ The following tasks ensure the server is able to use Python 3.
     ansible_python_interpreter: /usr/bin/python3
 ```
 
-Note that `pip3` is automatically installed with Python 3.6, and that the
+Note that `pip3` is automatically installed with Python 3.6 and that the
 SELinux dependencies are required by some Ansible modules.
 
 ### Use pip3 to install packages
@@ -83,7 +81,7 @@ packages to the system's Python 3.
 
 ### Tell Ansible to use Python 3 interpreter where required
 
-Ansible uses the `ansible_python_interpreter` variable to define with Python to
+Ansible uses the `ansible_python_interpreter` variable to define which Python to
 use.  This must be specified wherever a module uses a Python 3 dependency e.g.
 
 ```yaml
@@ -100,7 +98,8 @@ use.  This must be specified wherever a module uses a Python 3 dependency e.g.
 
 Ansible reads variable definitions according to a [defined
 hierarchy](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable).
-In the example above, the variable sets Python 3 as interpreter for a single
-task and Python 2 is used elsewhere.  We find this preferable as it is most
-explicit and some other modules, most notably `yum`, will only work with Python
+In the example above, the variable only applies for a single
+task and Python 2 is used elsewhere.  We find this preferable to setting for
+an entire host or play as the intention is most
+explicit and some other modules, notably `yum`, will only work with Python
 2.

--- a/_posts/2020-02-21-centos7-python2-end-of-life.md
+++ b/_posts/2020-02-21-centos7-python2-end-of-life.md
@@ -10,7 +10,7 @@ tags:
   - continuous-integration
 ---
 
-The [sunsetting of Python 2](https://www.python.org/doc/sunset-python-2/) on 1 January 2020 has started to cause problems our CentOS 7 server administration.
+The [sunsetting of Python 2](https://www.python.org/doc/sunset-python-2/) on 1 January 2020 has been causing problems our CentOS 7 server administration.
 We use [Ansible](https://www.ansible.com/) for automatic configuration and
 a few of our long-used jobs recently began to fail as a result Python 2 / Python 3 mismatches.
 Officially, CentOS 7 is [supported until

--- a/_posts/2020-02-21-centos7-python2-end-of-life.md
+++ b/_posts/2020-02-21-centos7-python2-end-of-life.md
@@ -105,5 +105,4 @@ an entire host or play as the intention is most
 explicit and some other modules, notably `yum`, will only work with Python
 2.
 
-Trivia: `yum` ("Yellowdog updater, modified") is the package manager in CentOS
-7.  It requires Python 2.  CentOS 8 uses `dnf` package manager ("Dandified Yum"), which can use Python 3.
+Trivia: `yum` ("Yellowdog updater, modified") is the package manager in CentOS 7.  It requires Python 2.  CentOS 8 uses `dnf` package manager ("Dandified Yum"), which can use Python 3.

--- a/_posts/2020-02-21-centos7-python2-end-of-life.md
+++ b/_posts/2020-02-21-centos7-python2-end-of-life.md
@@ -28,7 +28,7 @@ Hopefully they will be helpful to others.
 ## Background
 
 Ansible configures servers by connecting via SSH and running
-shell scripts and/or Python scripts to apply the settings that you requested.
+shell scripts and/or Python scripts to apply the requested settings.
 In CentOS 7, these scripts are run by Python 2.7.
 This causes two main problems with Python tools installed using the `pip`
 package manager:
@@ -100,6 +100,9 @@ use.  This must be specified wherever a module uses a Python 3 dependency e.g.
   vars:
     ansible_python_interpreter: /usr/bin/python3
 ```
+
+Without this setting, the task will fail with an `ImportError` as the Python
+2 interpreter fails to find the library installed via `pip3`.
 
 Ansible reads variable definitions according to a [defined
 hierarchy](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable).


### PR DESCRIPTION
### Blog Post Title

* CentOS 7, Ansible and the end of Python 2

This post summarises Declan and I's findings after we spend lots of this week fixing our Ansible / pipeline issue.  We didn't find a single compilation of information about these problems online, so this post should be useful for others outside BGS as well as providing a reference for whenever we hit these problems again.

### Link to rendered version

Please include a link to the rendered version of your blog post so it can be seen its intended display format,

* https://volcan01010.github.io/BritishGeologicalSurvey.github.io/devops/centos7-python2-end-of-life/